### PR TITLE
Changing USB Feature to not required

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.example.quick_usb">
-    <uses-feature android:name="android.hardware.usb.host" android:required="true"/>
+    <uses-feature android:name="android.hardware.usb.host" android:required="false"/>
 </manifest>


### PR DESCRIPTION
after struggling with play store for a while there's devices that doesn't have the usb feature in it's system so making this feature required made play store excluded all this devices which is around 3000 device