### PR TITLE
Add "requestPermission" option to "getDevicesWithDescription".

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,16 @@ Returns devices list with manufacturer, product and serial number description.
 
 Any of these attributes can be null.
 
-On Android user will be asked for permission for each device if needed.
-
 ```dart
 var descriptions = await QuickUsb.getDevicesWithDescription();
 var deviceList = descriptions.map((e) => e.device).toList();
 print('descriptions $descriptions');
+```
+
+**(Android Only)** Android requires permission for each device in order to get the serial number. The user will be asked
+for permission for each device if needed. If you do not require the serial number, you can avoid requesting permission using:
+```dart
+var descriptions = await QuickUsb.getDevicesWithDescription(requestPermission: false);
 ```
 
 ### Get device description
@@ -44,11 +48,15 @@ Returns manufacturer, product and serial number description for specified device
 
 Any of these attributes can be null.
 
-On Android user will be asked for permission if needed.
-
 ```dart
  var description = await QuickUsb.getDeviceDescription(device);
  print('description ${description.toMap()}');
+```
+
+**(Android Only)** Android requires permission for each device in order to get the serial number. The user will be asked
+for permission for each device if needed. If you do not require the serial number, you can avoid requesting permission using:
+```dart
+var description = await QuickUsb.getDeviceDescription(requestPermission: false);
 ```
 
 ### Check/Request permission

--- a/android/src/main/kotlin/com/example/quick_usb/QuickUsbPlugin.kt
+++ b/android/src/main/kotlin/com/example/quick_usb/QuickUsbPlugin.kt
@@ -16,9 +16,9 @@ import io.flutter.plugin.common.MethodChannel.Result
 
 private const val ACTION_USB_PERMISSION = "com.example.quick_usb.USB_PERMISSION"
 
-private val pendingIntentFlag = 
+private val pendingIntentFlag =
   if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-    PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT 
+    PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
   } else {
     PendingIntent.FLAG_UPDATE_CURRENT
   }
@@ -72,10 +72,42 @@ class QuickUsbPlugin : FlutterPlugin, MethodCallHandler {
                   "identifier" to it.key,
                   "vendorId" to it.value.vendorId,
                   "productId" to it.value.productId,
-                  "configurationCount" to it.value.configurationCount
+                  "configurationCount" to it.value.configurationCount,
+                  "manufacturer" to it.value.manufacturerName,
+                  "product" to it.value.productName,
+                  "serialNumber" to if (manager.hasPermission(it.value)) it.value.serialNumber else null,
           )
         }
         result.success(usbDeviceList)
+      }
+      "getDeviceDescription" -> {
+        val context = applicationContext ?: return result.error("IllegalState", "applicationContext null", null)
+        val manager = usbManager ?: return result.error("IllegalState", "usbManager null", null)
+        val identifier = call.argument<Map<String, Any>>("device")!!["identifier"]!!;
+        val device = manager.deviceList[identifier] ?: return result.error("IllegalState", "usbDevice null", null)
+        val requestPermission = call.argument<Boolean>("requestPermission")!!;
+
+        if (requestPermission && !manager.hasPermission(device)) {
+          val permissionReceiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent) {
+              context.unregisterReceiver(this)
+              val granted = intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false);
+              result.success(mapOf(
+                "manufacturer" to device.manufacturerName,
+                "product" to device.productName,
+                "serialNumber" to if (granted) device.serialNumber else null,
+              ))
+            }
+          }
+          context.registerReceiver(permissionReceiver, IntentFilter(ACTION_USB_PERMISSION))
+          manager.requestPermission(device, pendingPermissionIntent(context))
+        } else {
+          result.success(mapOf(
+            "manufacturer" to device.manufacturerName,
+            "product" to device.productName,
+            "serialNumber" to device.serialNumber
+          ))
+        }
       }
       "hasPermission" -> {
         val manager = usbManager ?: return result.error("IllegalState", "usbManager null", null)
@@ -187,37 +219,6 @@ class QuickUsbPlugin : FlutterPlugin, MethodCallHandler {
           result.error("unknown", "bulkTransferOut error", null)
         } else {
           result.success(sum)
-        }
-      }
-      "getDeviceDescription" -> {
-        val context = applicationContext ?: return result.error("IllegalState", "applicationContext null", null)
-        val manager = usbManager ?: return result.error("IllegalState", "usbManager null", null)
-        val identifier = call.argument<String>("identifier")
-        val device = manager.deviceList[identifier] ?: return result.error("IllegalState", "usbDevice null", null)
-        if (!manager.hasPermission(device)) {
-          val permissionReceiver = object : BroadcastReceiver() {
-            override fun onReceive(context: Context, intent: Intent) {
-              context.unregisterReceiver(this)
-              val granted = intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)
-              if (!granted) {
-                result.success(mapOf<String, String?>())
-              } else {
-                result.success(mapOf<String, String?>(
-                        "manufacturer" to device.manufacturerName,
-                        "product" to device.productName,
-                        "serialNumber" to device.serialNumber
-                ))
-              }
-            }
-          }
-          context.registerReceiver(permissionReceiver, IntentFilter(ACTION_USB_PERMISSION))
-          manager.requestPermission(device, pendingPermissionIntent(context))
-        } else {
-          result.success(mapOf<String, String?>(
-                  "manufacturer" to device.manufacturerName,
-                  "product" to device.productName,
-                  "serialNumber" to device.serialNumber
-          ))
         }
       }
       else -> result.notImplemented()

--- a/lib/quick_usb.dart
+++ b/lib/quick_usb.dart
@@ -39,6 +39,24 @@ class QuickUsb {
 
   static Future<List<UsbDevice>> getDeviceList() => _platform.getDeviceList();
 
+  /// [requestPermission] If true, Android will ask permission for each USB
+  /// device if required. Only required to retrieve the serial number.
+  static Future<List<UsbDeviceDescription>> getDevicesWithDescription({
+    bool requestPermission = true,
+  }) =>
+      _platform.getDevicesWithDescription(requestPermission: requestPermission);
+
+  /// [requestPermission] If true, Android will ask permission for the USB device
+  /// if required. Only required to retrieve the serial number.
+  static Future<UsbDeviceDescription> getDeviceDescription(
+    UsbDevice usbDevice, {
+    bool requestPermission = true,
+  }) =>
+      _platform.getDeviceDescription(
+        usbDevice,
+        requestPermission: requestPermission,
+      );
+
   static Future<bool> hasPermission(UsbDevice usbDevice) =>
       _platform.hasPermission(usbDevice);
 
@@ -72,13 +90,6 @@ class QuickUsb {
   static Future<int> bulkTransferOut(UsbEndpoint endpoint, Uint8List data,
           {int timeout = 1000}) =>
       _platform.bulkTransferOut(endpoint, data, timeout);
-
-  static Future<UsbDeviceDescription> getDeviceDescription(
-          UsbDevice usbDevice) =>
-      _platform.getDeviceDescription(usbDevice);
-
-  static Future<List<UsbDeviceDescription>> getDevicesWithDescription() =>
-      _platform.getDevicesWithDescription();
 
   static Future<void> setAutoDetachKernelDriver(bool enable) =>
       _platform.setAutoDetachKernelDriver(enable);

--- a/lib/src/quick_usb_android.dart
+++ b/lib/src/quick_usb_android.dart
@@ -20,9 +20,61 @@ class QuickUsbAndroid extends QuickUsbPlatform {
 
   @override
   Future<List<UsbDevice>> getDeviceList() async {
-    List<Map<dynamic, dynamic>> list =
-        (await _channel.invokeListMethod('getDeviceList'))!;
-    return list.map((e) => UsbDevice.fromMap(e)).toList();
+    final devices = await _getDevices(requestPermission: false);
+    return devices.map((device) => UsbDevice.fromMap(device)).toList();
+  }
+
+  Future<List<Map<dynamic, dynamic>>> _getDevices(
+      {required bool requestPermission}) async {
+    final result = (await _channel.invokeListMethod<Map<dynamic, dynamic>>(
+      'getDeviceList',
+      {'requestPermission': requestPermission},
+    ))!;
+    return result;
+  }
+
+  @override
+  Future<List<UsbDeviceDescription>> getDevicesWithDescription({
+    bool requestPermission = true,
+  }) async {
+    if (requestPermission) {
+      // Get each device description separately, asking permission for each device
+      var devices = await getDeviceList();
+      var result = <UsbDeviceDescription>[];
+      for (var device in devices) {
+        result.add(await getDeviceDescription(device, requestPermission: true));
+      }
+      return result;
+    } else {
+      final devices = await _getDevices(requestPermission: false);
+      return devices
+          .map(
+            (device) => UsbDeviceDescription.fromMap({
+              'device': device,
+              'manufacturer': device['manufacturer'],
+              'product': device['product'],
+              'serialNumber': device['serialNumber'],
+            }),
+          )
+          .toList();
+    }
+  }
+
+  @override
+  Future<UsbDeviceDescription> getDeviceDescription(
+    UsbDevice usbDevice, {
+    bool requestPermission = true,
+  }) async {
+    var result = await _channel.invokeMethod('getDeviceDescription', {
+      'device': usbDevice.toMap(),
+      'requestPermission': requestPermission,
+    });
+    return UsbDeviceDescription(
+      device: usbDevice,
+      manufacturer: result['manufacturer'],
+      product: result['product'],
+      serialNumber: result['serialNumber'],
+    );
   }
 
   @override
@@ -98,28 +150,6 @@ class QuickUsbAndroid extends QuickUsbPlatform {
       'data': data,
       'timeout': timeout,
     });
-  }
-
-  @override
-  Future<UsbDeviceDescription> getDeviceDescription(UsbDevice usbDevice) async {
-    var result =
-        await _channel.invokeMethod('getDeviceDescription', usbDevice.toMap());
-    return UsbDeviceDescription(
-      device: usbDevice,
-      manufacturer: result['manufacturer'],
-      product: result['product'],
-      serialNumber: result['serialNumber'],
-    );
-  }
-
-  @override
-  Future<List<UsbDeviceDescription>> getDevicesWithDescription() async {
-    var devices = await getDeviceList();
-    var result = <UsbDeviceDescription>[];
-    for (var device in devices) {
-      result.add(await getDeviceDescription(device));
-    }
-    return result;
   }
 
   @override

--- a/lib/src/quick_usb_desktop.dart
+++ b/lib/src/quick_usb_desktop.dart
@@ -83,6 +83,72 @@ class _QuickUsbDesktop extends QuickUsbPlatform {
   }
 
   @override
+  Future<List<UsbDeviceDescription>> getDevicesWithDescription({bool requestPermission = true}) async {
+    var devices = await getDeviceList();
+    var result = <UsbDeviceDescription>[];
+    for (var device in devices) {
+      result.add(await getDeviceDescription(device));
+    }
+    return result;
+  }
+
+  @override
+  Future<UsbDeviceDescription> getDeviceDescription(UsbDevice usbDevice, {bool requestPermission = true}) async {
+    String? manufacturer;
+    String? product;
+    String? serialNumber;
+    var descPtr = ffi.calloc<libusb_device_descriptor>();
+    try {
+      var handle = _libusb.libusb_open_device_with_vid_pid(
+          nullptr, usbDevice.vendorId, usbDevice.productId);
+      if (handle != nullptr) {
+        var device = _libusb.libusb_get_device(handle);
+        if (device != nullptr) {
+          var getDesc = _libusb.libusb_get_device_descriptor(device, descPtr) ==
+              libusb_error.LIBUSB_SUCCESS;
+          if (getDesc) {
+            if (descPtr.ref.iManufacturer > 0) {
+              manufacturer =
+                  _getStringDescriptorASCII(handle, descPtr.ref.iManufacturer);
+            }
+            if (descPtr.ref.iProduct > 0) {
+              product = _getStringDescriptorASCII(handle, descPtr.ref.iProduct);
+            }
+            if (descPtr.ref.iSerialNumber > 0) {
+              serialNumber =
+                  _getStringDescriptorASCII(handle, descPtr.ref.iSerialNumber);
+            }
+          }
+        }
+        _libusb.libusb_close(handle);
+      }
+    } finally {
+      ffi.calloc.free(descPtr);
+    }
+    return UsbDeviceDescription(
+        device: usbDevice,
+        manufacturer: manufacturer,
+        product: product,
+        serialNumber: serialNumber);
+  }
+
+  String? _getStringDescriptorASCII(
+      Pointer<libusb_device_handle> handle, int descIndex) {
+    String? result;
+    Pointer<ffi.Utf8> string = ffi.calloc<Uint8>(256).cast();
+    try {
+      var ret = _libusb.libusb_get_string_descriptor_ascii(
+          handle, descIndex, string.cast(), 256);
+      if (ret > 0) {
+        result = string.toDartString();
+      }
+    } finally {
+      ffi.calloc.free(string);
+    }
+    return result;
+  }
+
+  @override
   Future<bool> hasPermission(UsbDevice usbDevice) async {
     return true;
   }
@@ -264,72 +330,6 @@ class _QuickUsbDesktop extends QuickUsbPlatform {
       ffi.calloc.free(actualLengthPtr);
       ffi.calloc.free(dataPtr);
     }
-  }
-
-  @override
-  Future<UsbDeviceDescription> getDeviceDescription(UsbDevice usbDevice) async {
-    String? manufacturer;
-    String? product;
-    String? serialNumber;
-    var descPtr = ffi.calloc<libusb_device_descriptor>();
-    try {
-      var handle = _libusb.libusb_open_device_with_vid_pid(
-          nullptr, usbDevice.vendorId, usbDevice.productId);
-      if (handle != nullptr) {
-        var device = _libusb.libusb_get_device(handle);
-        if (device != nullptr) {
-          var getDesc = _libusb.libusb_get_device_descriptor(device, descPtr) ==
-              libusb_error.LIBUSB_SUCCESS;
-          if (getDesc) {
-            if (descPtr.ref.iManufacturer > 0) {
-              manufacturer =
-                  _getStringDescriptorASCII(handle, descPtr.ref.iManufacturer);
-            }
-            if (descPtr.ref.iProduct > 0) {
-              product = _getStringDescriptorASCII(handle, descPtr.ref.iProduct);
-            }
-            if (descPtr.ref.iSerialNumber > 0) {
-              serialNumber =
-                  _getStringDescriptorASCII(handle, descPtr.ref.iSerialNumber);
-            }
-          }
-        }
-        _libusb.libusb_close(handle);
-      }
-    } finally {
-      ffi.calloc.free(descPtr);
-    }
-    return UsbDeviceDescription(
-        device: usbDevice,
-        manufacturer: manufacturer,
-        product: product,
-        serialNumber: serialNumber);
-  }
-
-  String? _getStringDescriptorASCII(
-      Pointer<libusb_device_handle> handle, int descIndex) {
-    String? result;
-    Pointer<ffi.Utf8> string = ffi.calloc<Uint8>(256).cast();
-    try {
-      var ret = _libusb.libusb_get_string_descriptor_ascii(
-          handle, descIndex, string.cast(), 256);
-      if (ret > 0) {
-        result = string.toDartString();
-      }
-    } finally {
-      ffi.calloc.free(string);
-    }
-    return result;
-  }
-
-  @override
-  Future<List<UsbDeviceDescription>> getDevicesWithDescription() async {
-    var devices = await getDeviceList();
-    var result = <UsbDeviceDescription>[];
-    for (var device in devices) {
-      result.add(await getDeviceDescription(device));
-    }
-    return result;
   }
 
   @override

--- a/lib/src/quick_usb_platform_interface.dart
+++ b/lib/src/quick_usb_platform_interface.dart
@@ -28,6 +28,12 @@ abstract class QuickUsbPlatform extends PlatformInterface {
 
   Future<List<UsbDevice>> getDeviceList();
 
+  Future<List<UsbDeviceDescription>> getDevicesWithDescription(
+      {bool requestPermission = true});
+
+  Future<UsbDeviceDescription> getDeviceDescription(UsbDevice usbDevice,
+      {bool requestPermission = true});
+
   Future<bool> hasPermission(UsbDevice usbDevice);
 
   Future<void> requestPermission(UsbDevice usbDevice);
@@ -51,10 +57,6 @@ abstract class QuickUsbPlatform extends PlatformInterface {
 
   Future<int> bulkTransferOut(
       UsbEndpoint endpoint, Uint8List data, int timeout);
-
-  Future<UsbDeviceDescription> getDeviceDescription(UsbDevice usbDevice);
-
-  Future<List<UsbDeviceDescription>> getDevicesWithDescription();
 
   Future<void> setAutoDetachKernelDriver(bool enable);
 }


### PR DESCRIPTION
Currently, when running "getDevicesWithDescription" on Android, it asks permission for each device.

1. This is quite annoying, especially if you have a lot of devices.
2.  Also it seems redundant as you can get  the "manufacturer" or "product" name without permission. You only need permission for the serial number.

Therefore I've added a "requestPermission" option to allow the developer to decide if they need the serial number and ask the user permission to access each device.

Other changes:
 - Re-arrange code so "getDevicesWithDescription" and "getDeviceDescription" is below "getDeviceList"
 - On Android, if permission is denied when running "getDeviceDescription", still return the USB "manufacturer" and "product" name, instead of nothing.